### PR TITLE
Add recursion-schemes required for cardano-base

### DIFF
--- a/src/cabal2obs/Config/Ghc810x.hs
+++ b/src/cabal2obs/Config/Ghc810x.hs
@@ -371,6 +371,7 @@ constraintList = [ "adjunctions"
                  , "QuickCheck"
                  , "quickcheck-io"
                  , "random <1.2"        -- don't update yet (2020-07-07)
+                 , "recursion-schemes"
                  , "refact"
                  , "reflection"
                  , "regex-applicative"


### PR DESCRIPTION
- Dependency required by https://build.opensuse.org/package/show/devel:languages:haskell:cardano/ghc-cardano-binary
    - Upstream: https://github.com/input-output-hk/cardano-base