### PR TITLE
Limit recursion-schemes version to < 5.2.0

### DIFF
--- a/src/cabal2obs/Config/Ghc810x.hs
+++ b/src/cabal2obs/Config/Ghc810x.hs
@@ -371,7 +371,7 @@ constraintList = [ "adjunctions"
                  , "QuickCheck"
                  , "quickcheck-io"
                  , "random <1.2"        -- don't update yet (2020-07-07)
-                 , "recursion-schemes"
+                 , "recursion-schemes < 5.2.0"        -- cardano-binary-1.5.0 requires version = 5.1.x
                  , "refact"
                  , "reflection"
                  , "regex-applicative"


### PR DESCRIPTION
- cardano-binary-1.5.0 requires `recursion-schemes ==5.1.*`
    - upstream tracking input-output-hk/cardano-node#1997