### PR TITLE
build: relax overspecified contraint on base

### DIFF
--- a/patches/ghc-9.0.x/ekg-json/relax-overspecified-constraint-on-base.patch
+++ b/patches/ghc-9.0.x/ekg-json/relax-overspecified-constraint-on-base.patch
@@ -1,0 +1,12 @@
+Index: ghc-ekg-json.spec
+===================================================================
+--- ghc-ekg-json.spec   (revision 1)
++++ ghc-ekg-json.spec   (working copy)
+@@ -50,6 +50,7 @@
+ %prep
+ %autosetup -n %{pkg_name}-%{version}
+ cp -p %{SOURCE1} %{pkg_name}.cabal
++cabal-tweak-dep-ver base '< 4.15' '< 5'
+
+ %build
+ %ghc_lib_build


### PR DESCRIPTION
Fixed in upstream, but Hackage won't be updated until GHC 9.0.1 is out...

https://github.com/tibbe/ekg-json/pull/11