### PR TITLE
Fix GHC 9.0.x build for ghc-protolude package

### DIFF
--- a/patches/ghc-9.0.x/protolude/relax-overspecified-constraints.patch
+++ b/patches/ghc-9.0.x/protolude/relax-overspecified-constraints.patch
@@ -1,0 +1,13 @@
+Index: ghc-protolude.spec
+===================================================================
+--- ghc-protolude.spec	(revision 1)
++++ ghc-protolude.spec	(working copy)
+@@ -54,6 +54,8 @@
+ 
+ %prep
+ %autosetup -n %{pkg_name}-%{version}
++cabal-tweak-dep-ver base '<4.15' '< 5'
++cabal-tweak-dep-ver ghc-prim '<0.7' '< 0.8'
+ 
+ %build
+ %ghc_lib_build


### PR DESCRIPTION
Build log: [ghc-9.0.x-ghc-protolude-build.log](https://github.com/opensuse-haskell/configuration/files/5690279/ghc-9.0.x-ghc-protolude-build.log)
