### PR TITLE
Fix GHC 9.0.x build for ghc-text-format package

### DIFF
--- a/patches/ghc-9.0.x/text-format/relax-overspecified-constraint-on-base.patch
+++ b/patches/ghc-9.0.x/text-format/relax-overspecified-constraint-on-base.patch
@@ -1,0 +1,12 @@
+Index: ghc-text-format.spec
+===================================================================
+--- ghc-text-format.spec	(revision 1)
++++ ghc-text-format.spec	(working copy)
+@@ -50,6 +50,7 @@
+ %prep
+ %autosetup -n %{pkg_name}-%{version}
+ cp -p %{SOURCE1} %{pkg_name}.cabal
++cabal-tweak-dep-ver base '<4.15' '< 5'
+ 
+ %build
+ %ghc_lib_build


### PR DESCRIPTION
Build log: [ghc-9.0.x-ghc-text-format-build.log](https://github.com/opensuse-haskell/configuration/files/5690275/ghc-9.0.x-ghc-text-format-build.log)
