### PR TITLE
Fix GHC 9.0.x build for ghc-lib-parser package

### DIFF
--- a/patches/ghc-9.0.x/ghc-lib-parser/relax-overspecified-constraints.patch
+++ b/patches/ghc-9.0.x/ghc-lib-parser/relax-overspecified-constraints.patch
@@ -1,0 +1,13 @@
+Index: ghc-ghc-lib-parser.spec
+===================================================================
+--- ghc-ghc-lib-parser.spec	(revision 1)
++++ ghc-ghc-lib-parser.spec	(working copy)
+@@ -58,6 +58,8 @@
+ 
+ %prep
+ %autosetup -n %{pkg_name}-%{version}
++cabal-tweak-dep-ver base '< 4.15' '< 5'
++cabal-tweak-dep-ver ghc-prim '< 0.7' '< 0.8'
+ 
+ %build
+ %ghc_lib_build


### PR DESCRIPTION
After relaxing constraints, build fails with:

```
[  148s] [ 66 of 228] Compiling Util             ( compiler/utils/Util.hs, dist/build/Util.o, dist/build/Util.dyn_o )
[  148s]
[  148s] compiler/utils/Util.hs:43:28: error:
[  148s]     Ambiguous occurrence ‘singleton’
[  148s]     It could refer to
[  148s]        either ‘Data.List.singleton’,
[  148s]               imported from ‘Data.List’ at compiler/utils/Util.hs:141:1-38
[  148s]               (and originally defined in ‘base-4.15.0.0:Data.OldList’)
[  148s]            or ‘Util.singleton’, defined at compiler/utils/Util.hs:558:1
[  148s]    |
[  148s] 43 |         isSingleton, only, singleton,
[  148s]    |                            ^^^^^^^^^
[  148s] error: Bad exit status from /var/tmp/rpm-tmp.LcVJHi (%build)
[  148s]
[  148s]
[  148s] RPM build errors:
[  148s]     Bad exit status from /var/tmp/rpm-tmp.LcVJHi (%build)
[  148s]
[  148s] mark-asus-zenbook-s failed "build ghc-ghc-lib-parser.spec" at Tue Dec 15 13:19:27 UTC 2020.
[  148s]

The buildroot was: /var/tmp/build-root/openSUSE_Tumbleweed-x86_64
```