### PR TITLE
fix: update submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 
 [submodule "tools/spec-cleaner"]
 	path = src/spec-cleaner
-	url = git://github.com/openSUSE/spec-cleaner.git
+	url = https://github.com/rpm-software-management/spec-cleaner.git


### PR DESCRIPTION
It seems the submodule URL has changed. Github now points openSUSE/spec-cleaner to rpm-software-management/spec-cleaner.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>